### PR TITLE
Add manual metadata for aastex document

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf PSTN-052.pdf --ltd-product pstn-052
+          lander --upload --pdf PSTN-052.pdf --ltd-product pstn-052 --title "Survey Strategy: Rolling Cadence" --handle "PSTN-052" --author "Peter Yoachim"


### PR DESCRIPTION
Lander 2 will have a parser for aastex documents, but at the current moment we'll need to manually set this metadata for the landing page.