### PR TITLE
DM-52200: Add acronyms back in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ $(DOCNAME).pdf: $(tex) meta.tex local.bib authors.tex acronyms.tex
 
 # Acronym tool allows for selection of acronyms based on tags - you may want more than DM
 acronyms.tex: $(tex) myacronyms.txt
-	$(TEXMFHOME)/../bin/generateAcronyms.py -t "DM" $(tex)
+	$(TEXMFHOME)/../bin/generateAcronyms.py -m aastex -t "DM" $(tex)
 
 authors.tex:  authors.yaml
-	python3 $(TEXMFHOME)/../bin/db2authors.py > authors.tex 
+	python3 $(TEXMFHOME)/../bin/db2authors.py > authors.tex
 
 .PHONY: clean
 clean:

--- a/PSTN-052.tex
+++ b/PSTN-052.tex
@@ -226,7 +226,7 @@ We could expand the half-sky rolling to include and additional rolling cycle (fo
 \bibliography{local,lsst,lsst-dm,refs_ads,refs,books}
 
 % Make sure lsst-texmf/bin/generateAcronyms.py is in your path
-%\section{Acronyms} \label{sec:acronyms}
-%\input{acronyms.tex}
+\section{Acronyms} \label{sec:acronyms}
+\input{acronyms.tex}
 
 \end{document}


### PR DESCRIPTION
longtable with p{} cell does not work with AASTeX